### PR TITLE
⚡️ Feat [Board CRUD]

### DIFF
--- a/src/auth/decorator/getUser.decorator.ts
+++ b/src/auth/decorator/getUser.decorator.ts
@@ -1,0 +1,10 @@
+import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+import { User } from '../entity/user.entity';
+
+export const GetUser = createParamDecorator(
+  (data, context: ExecutionContext): User => {
+    const req = context.switchToHttp().getRequest();
+
+    return req.user;
+  },
+);

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -1,12 +1,27 @@
 import { User } from './../auth/entity/user.entity';
-import { JwtAccessGuard } from 'src/auth/token/jwt-access.guard';
 import { BoardsService } from './boards.service';
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { BoardDto } from './dto/board.dto';
 import { Board } from './entity/board.entity';
+import { GetUser } from 'src/auth/decorator/getUser.decorator';
+import { AuthGuard } from '@nestjs/passport';
+import { GetBoardsDto } from './dto/getBoards.dto';
+import { OwnershipGuard } from './guard/ownership.guard';
+import { BoardStatusValidationPipe } from './pipe/boardStatusValidation.pipe';
 
 @Controller('boards')
-@UseGuards(JwtAccessGuard)
+@UseGuards(AuthGuard('jwt'))
 export class BoardsController {
   constructor(private BoardsService: BoardsService) {}
 
@@ -14,9 +29,40 @@ export class BoardsController {
   @Post('/create')
   async createBoard(
     @Body() BoardDto: BoardDto,
-    @Req() req: any,
+    @GetUser() user: User,
   ): Promise<Board> {
-    const user = req.user;
     return this.BoardsService.createBoard(BoardDto, user);
+  }
+
+  // 모든 게시물 조회
+  @Get()
+  async getBoards(@Query('page') page: number): Promise<GetBoardsDto> {
+    return await this.BoardsService.getBoards(page);
+  }
+
+  // 나의 게시물 조회
+  @Get('/:username')
+  async getMyBoards(
+    @GetUser() user: User,
+    @Query('page') page: number,
+  ): Promise<GetBoardsDto> {
+    return await this.BoardsService.getMyBoards(user, page);
+  }
+
+  // 게시물 수정
+  @Patch('/:id')
+  @UseGuards(OwnershipGuard) // 본인 게시물 확인
+  updateBoard(
+    @Param('id', ParseIntPipe) id: number,
+    @Body(BoardStatusValidationPipe) BoardDto: BoardDto, // 게시물 상태 확인
+  ): Promise<Board> {
+    return this.BoardsService.updateBoard(id, BoardDto);
+  }
+
+  // 게시물 삭제
+  @Delete('/:id')
+  @UseGuards(OwnershipGuard)
+  deleteBoard(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    return this.BoardsService.deleteBoard(id);
   }
 }

--- a/src/boards/boards.module.ts
+++ b/src/boards/boards.module.ts
@@ -2,8 +2,11 @@ import { Module } from '@nestjs/common';
 import { BoardsController } from './boards.controller';
 import { BoardsService } from './boards.service';
 import { BoardRepository } from './boards.repository';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Board } from './entity/board.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Board])],
   controllers: [BoardsController],
   providers: [BoardsService, BoardRepository],
 })

--- a/src/boards/boards.repository.ts
+++ b/src/boards/boards.repository.ts
@@ -1,7 +1,11 @@
 import { BoardDto } from './dto/board.dto';
 import { DataSource, Repository } from 'typeorm';
 import { Board } from './entity/board.entity';
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { User } from 'src/auth/entity/user.entity';
 
 @Injectable()
@@ -30,5 +34,29 @@ export class BoardRepository extends Repository<Board> {
         '게시물 생성 중 오류가 발생했습니다.',
       );
     }
+  }
+
+  // 게시물 수정
+  async updateBoard(id: number, BoardDto: BoardDto): Promise<Board> {
+    const board = await this.findOne({ where: { id } });
+
+    board.description = BoardDto.description;
+    board.status = BoardDto.status;
+
+    await this.save(board);
+
+    return board;
+  }
+
+  // 게시물 삭제
+  async deleteBoard(id: number): Promise<void> {
+    const board = await this.findOne({ where: { id } });
+
+    if (!board) {
+      throw new NotFoundException('일치하는 게시물이 없습니다.');
+    }
+
+    // 논리적 삭제
+    await this.softDelete(id);
   }
 }

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -1,14 +1,67 @@
 import { BoardDto } from './dto/board.dto';
 import { BoardRepository } from './boards.repository';
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { User } from 'src/auth/entity/user.entity';
 import { Board } from './entity/board.entity';
+import { GetBoardsDto } from './dto/getBoards.dto';
 
 @Injectable()
 export class BoardsService {
   constructor(private BoardRepository: BoardRepository) {}
 
+  // 게시물 생성
   createBoard(BoardDto: BoardDto, user: User): Promise<Board> {
     return this.BoardRepository.createBoard(BoardDto, user);
+  }
+
+  // 모든 게시물 조회
+  async getBoards(page: number): Promise<GetBoardsDto> {
+    const pageSize = 2;
+
+    const [boards, total] = await this.BoardRepository.findAndCount({
+      // 가져올 게시글의 갯수
+      take: pageSize,
+
+      // 생략할 게시글의 갯수
+      skip: page <= 0 ? 0 : (page - 1) * pageSize,
+    });
+
+    const lastPage = Math.ceil(total / pageSize);
+
+    if (lastPage >= page) {
+      return { boards, total };
+    } else {
+      throw new NotFoundException('해당 페이지는 존재하지 않습니다.');
+    }
+  }
+
+  // 나의 게시물 조회
+  async getMyBoards(user: User, page: number): Promise<GetBoardsDto> {
+    const pageSize = 2;
+    const userId = user.id;
+
+    const [boards, total] = await this.BoardRepository.findAndCount({
+      where: { user: { id: userId } },
+      take: pageSize,
+      skip: page <= 0 ? 0 : (page - 1) * pageSize,
+    });
+
+    const lastPage = Math.ceil(total / pageSize);
+
+    if (lastPage >= page) {
+      return { boards, total };
+    } else {
+      throw new NotFoundException('해당 페이지는 존재하지 않습니다.');
+    }
+  }
+
+  // 게시물 수정
+  updateBoard(id: number, BoardDto: BoardDto): Promise<Board> {
+    return this.BoardRepository.updateBoard(id, BoardDto);
+  }
+
+  // 게시물 삭제
+  deleteBoard(id: number): Promise<void> {
+    return this.BoardRepository.deleteBoard(id);
   }
 }

--- a/src/boards/dto/board.dto.ts
+++ b/src/boards/dto/board.dto.ts
@@ -1,6 +1,12 @@
-import { IsNotEmpty } from 'class-validator';
+import { IS_IN, IsNotEmpty, IsString } from 'class-validator';
+import { BoardStatus } from '../board.model';
+import { Transform } from 'class-transformer';
+import { BeforeInsert, BeforeUpdate } from 'typeorm';
 
 export class BoardDto {
   @IsNotEmpty()
+  @IsString()
   description: string;
+
+  status?: BoardStatus;
 }

--- a/src/boards/dto/getBoards.dto.ts
+++ b/src/boards/dto/getBoards.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty } from 'class-validator';
+import { Board } from '../entity/board.entity';
+
+export class GetBoardsDto {
+  boards: Board[];
+  total: number;
+}

--- a/src/boards/entity/board.entity.ts
+++ b/src/boards/entity/board.entity.ts
@@ -2,6 +2,7 @@ import { User } from 'src/auth/entity/user.entity';
 import {
   BaseEntity,
   Column,
+  DeleteDateColumn,
   Entity,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -23,4 +24,7 @@ export class Board extends BaseEntity {
     eager: false,
   })
   user: User;
+
+  @DeleteDateColumn()
+  deletedAt: Date | null;
 }

--- a/src/boards/guard/ownership.guard.ts
+++ b/src/boards/guard/ownership.guard.ts
@@ -1,0 +1,39 @@
+import { BoardRepository } from './../boards.repository';
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+
+@Injectable()
+export class OwnershipGuard implements CanActivate {
+  constructor(private readonly BoardRepository: BoardRepository) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const boardId = request.params.id;
+
+    const board = await this.BoardRepository.findOne({
+      where: { id: boardId },
+      relations: ['user'],
+    });
+
+    if (!board) {
+      throw new ForbiddenException('게시물을 찾을 수 없습니다.');
+    }
+
+    if (!board.user) {
+      throw new ForbiddenException('게시물 작성자를 확인할 수 없습니다.');
+    }
+
+    if (board.user.id !== user.id) {
+      throw new ForbiddenException(
+        '본인이 작성한 게시물만 수정할 수 있습니다.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/boards/pipe/boardStatusValidation.pipe.ts
+++ b/src/boards/pipe/boardStatusValidation.pipe.ts
@@ -1,0 +1,23 @@
+import { BadRequestException, PipeTransform } from '@nestjs/common';
+import { BoardStatus } from '../board.model';
+
+export class BoardStatusValidationPipe implements PipeTransform {
+  readonly StatusOption = ['PUBLIC', 'PRIVATE'];
+
+  transform(value: any) {
+    const status = value.status.toUpperCase();
+
+    if (!this.isStatusValid(status)) {
+      throw new BadRequestException(`${status}는 적절한 상태가 아닙니다.`);
+    }
+
+    value.status = status;
+
+    return value;
+  }
+
+  private isStatusValid(status: BoardStatus) {
+    const index = this.StatusOption.indexOf(status);
+    return index !== -1;
+  }
+}


### PR DESCRIPTION
# ⚡ PR 요약

1. Board CRUD 구현

# 🔍 주요 변경 사항

### 1. Board Controller
- AuthGuard를 이용하여 인가된 사용자만 접근하도록 구현

### 2. Board Create
- 사용자(OneToMany) <-> 게시글(ManyToOne) 관계로 생성

### 3. Board Read
- 모든 게시물, 사용자 게시물 가져오기 구현
- Query 데코레이터를 통해 url로 page 데이터 전달
- BoardRepository.findAndCount()을 이용한 pagination 구현

### 4. Board Update
- OwnershipGuard 구현으로 본인 게시글만 수정 가능
- BoardStatusValidationPipe을 통해 적절한 상태값만 저장 가능하도록 구현

### 5. Board Delete
- OwnershipGuard 구현으로 본인 게시글만 삭제 가능
- softDelete를 통한 논리적 삭제 (물리적 삭제의 위험성으로 논리적 삭제로 결정)

# 💡 관련 이슈

Resolve #8 
